### PR TITLE
Implement basic auth and service modules

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,11 @@
+import { ButtonHTMLAttributes } from 'react';
+
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary';
+}
+
+export default function Button({ variant = 'primary', ...rest }: Props) {
+  const base = 'px-4 py-2 rounded';
+  const cls = variant === 'primary' ? `${base} bg-blue-600 text-white` : `${base} bg-gray-200`;
+  return <button className={cls} {...rest} />;
+}

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,0 +1,14 @@
+import { InputHTMLAttributes } from 'react';
+
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+}
+
+export default function Input({ label, ...rest }: Props) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span>{label}</span>
+      <input className="border p-2 rounded" {...rest} />
+    </label>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,5 +1,43 @@
+import { Link } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+
 export default function Navbar() {
+  const { role, logout } = useAuth();
+
   return (
-    <nav className="bg-gray-800 text-white p-4">Nav</nav>
+    <nav className="bg-gray-800 text-white p-4 flex justify-between">
+      <div className="font-bold">Servicios</div>
+      <div className="space-x-4">
+        {role === 'CLIENTE' && (
+          <>
+            <Link to="/cliente/dashboard" className="hover:underline">
+              Inicio
+            </Link>
+            <Link to="/cliente/buscar" className="hover:underline">
+              Buscar
+            </Link>
+            <Link to="/cliente/reservas" className="hover:underline">
+              Reservas
+            </Link>
+          </>
+        )}
+        {role === 'PROVEEDOR' && (
+          <>
+            <Link to="/proveedor/dashboard" className="hover:underline">
+              Inicio
+            </Link>
+            <Link to="/proveedor/servicios" className="hover:underline">
+              Servicios
+            </Link>
+            <Link to="/proveedor/reservas" className="hover:underline">
+              Reservas
+            </Link>
+          </>
+        )}
+        <button onClick={logout} className="hover:underline">
+          Cerrar sesión
+        </button>
+      </div>
+    </nav>
   );
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,5 @@
+export default function Navbar() {
+  return (
+    <nav className="bg-gray-800 text-white p-4">Nav</nav>
+  );
+}

--- a/src/components/ReservationCard.tsx
+++ b/src/components/ReservationCard.tsx
@@ -1,0 +1,11 @@
+import { Reserva } from '../services/reservas';
+
+export default function ReservationCard({ reserva }: { reserva: Reserva }) {
+  return (
+    <div className="bg-white rounded shadow p-4">
+      <p>Fecha: {reserva.fechaReserva}</p>
+      <p>Dirección: {reserva.direccion}</p>
+      <p>Estado: {reserva.estado}</p>
+    </div>
+  );
+}

--- a/src/components/ReviewCard.tsx
+++ b/src/components/ReviewCard.tsx
@@ -1,0 +1,10 @@
+import { Resena } from '../services/resenas';
+
+export default function ReviewCard({ resena }: { resena: Resena }) {
+  return (
+    <div className="bg-white rounded shadow p-4">
+      <p className="font-semibold">Calificación: {resena.calificacion}</p>
+      <p>{resena.comentario}</p>
+    </div>
+  );
+}

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -1,0 +1,11 @@
+import { Servicio } from '../services/servicios';
+
+export default function ServiceCard({ servicio }: { servicio: Servicio }) {
+  return (
+    <div className="bg-white rounded shadow p-4">
+      <h3 className="font-bold">{servicio.nombre}</h3>
+      <p>{servicio.descripcion}</p>
+      <span className="text-sm">${servicio.precio}</span>
+    </div>
+  );
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -5,7 +5,7 @@ import { clearAuth, saveAuth } from '../utils/authHelpers';
 import * as authSvc from '../services/auth';
 
 export interface AuthState {
-  id: number;
+  userId: number;
   token: string;
   role: 'CLIENTE' | 'PROVEEDOR';
 }
@@ -63,7 +63,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   externalLogout = logout;
 
   const value: AuthContextType = {
-    id: auth?.id,
+    userId: auth?.userId,
     token: auth?.token,
     role: auth?.role,
     login,

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,63 @@
+import { createContext, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useStorageState } from '../hooks/useStorageState';
+import { clearAuth, saveAuth } from '../utils/authHelpers';
+import * as authSvc from '../services/auth';
+
+export interface AuthState {
+  userId: number;
+  token: string;
+  role: 'CLIENTE' | 'PROVEEDOR';
+}
+
+export interface AuthContextType extends Partial<AuthState> {
+  login: (c: { email: string; password: string }) => Promise<void>;
+  register: (d: { name: string; email: string; password: string; role: AuthState['role'] }) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | null>(null);
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('AuthProvider missing');
+  return ctx;
+}
+
+export let externalLogout = () => {};
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const navigate = useNavigate();
+  const [auth, setAuth] = useStorageState<AuthState | null>('auth', null);
+
+  async function login(cred: { email: string; password: string }) {
+    const data = await authSvc.login(cred);
+    setAuth(data);
+    saveAuth(data);
+  }
+
+  async function register(data: { name: string; email: string; password: string; role: AuthState['role'] }) {
+    const resp = data.role === 'CLIENTE' ? await authSvc.registerCliente(data) : await authSvc.registerProveedor(data);
+    setAuth(resp);
+    saveAuth(resp);
+  }
+
+  function logout() {
+    clearAuth();
+    setAuth(null);
+    navigate('/login');
+  }
+
+  externalLogout = logout;
+
+  const value: AuthContextType = {
+    userId: auth?.userId,
+    token: auth?.token,
+    role: auth?.role,
+    login,
+    register,
+    logout,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { router } from '../router/routes';
 import { useStorageState } from '../hooks/useStorageState';
 import { clearAuth, saveAuth } from '../utils/authHelpers';
 import * as authSvc from '../services/auth';
@@ -31,14 +31,13 @@ export function useAuth() {
 export let externalLogout = () => {};
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const navigate = useNavigate();
   const [auth, setAuth] = useStorageState<AuthState | null>('auth', null);
 
   async function login(cred: { email: string; password: string }) {
     const data = await authSvc.login(cred);
     setAuth(data);
     saveAuth(data);
-    navigate(data.role === 'CLIENTE' ? '/cliente/servicios' : '/proveedor/servicios');
+    router.navigate(data.role === 'CLIENTE' ? '/cliente/servicios' : '/proveedor/servicios');
   }
 
   async function register(
@@ -52,13 +51,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         : await authSvc.registerProveedor(data);
     setAuth(resp);
     saveAuth(resp);
-    navigate(resp.role === 'CLIENTE' ? '/cliente/servicios' : '/proveedor/servicios');
+    router.navigate(resp.role === 'CLIENTE' ? '/cliente/servicios' : '/proveedor/servicios');
   }
 
   function logout() {
     clearAuth();
     setAuth(null);
-    navigate('/login');
+    router.navigate('/login');
   }
 
   externalLogout = logout;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -45,7 +45,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const authData = { userId: resp.id, token: resp.token, role } as AuthState;
     setAuth(authData);
     saveAuth(authData);
-    router.navigate(role === 'CLIENTE' ? '/cliente/servicios' : '/proveedor/servicios');
+    router.navigate(role === 'CLIENTE' ? '/cliente/dashboard' : '/proveedor/dashboard');
   }
 
   async function register(
@@ -66,7 +66,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const authData = { userId: resp.id, token: resp.token, role } as AuthState;
     setAuth(authData);
     saveAuth(authData);
-    router.navigate(role === 'CLIENTE' ? '/cliente/servicios' : '/proveedor/servicios');
+    router.navigate(role === 'CLIENTE' ? '/cliente/dashboard' : '/proveedor/dashboard');
   }
 
   function logout() {

--- a/src/hooks/useStorageState.ts
+++ b/src/hooks/useStorageState.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+export function useStorageState<T>(key: string, initial: T): [T, (v: T) => void] {
+  const [value, setValue] = useState<T>(() => {
+    const raw = localStorage.getItem(key);
+    if (raw != null) {
+      try {
+        return JSON.parse(raw) as T;
+      } catch {
+        return initial;
+      }
+    }
+    return initial;
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      /* ignore */
+    }
+  }, [key, value]);
+
+  return [value, setValue];
+}

--- a/src/interfaces/auth/AuthResponse.ts
+++ b/src/interfaces/auth/AuthResponse.ts
@@ -1,5 +1,5 @@
 export interface AuthResponse {
-  id: number;
+  userId: number;
   token: string;
   role: 'CLIENTE' | 'PROVEEDOR';
 }

--- a/src/interfaces/auth/AuthResponse.ts
+++ b/src/interfaces/auth/AuthResponse.ts
@@ -1,5 +1,5 @@
 export interface AuthResponse {
-  userId: number;
+  id: number;
   token: string;
   role: 'CLIENTE' | 'PROVEEDOR';
 }

--- a/src/interfaces/auth/AuthResponse.ts
+++ b/src/interfaces/auth/AuthResponse.ts
@@ -1,5 +1,5 @@
 export interface AuthResponse {
-  userId: number;
+  id: number;
   token: string;
-  role: 'CLIENTE' | 'PROVEEDOR';
+  role?: 'CLIENTE' | 'PROVEEDOR';
 }

--- a/src/interfaces/auth/AuthResponse.ts
+++ b/src/interfaces/auth/AuthResponse.ts
@@ -1,1 +1,5 @@
-export interface AuthResponse {}
+export interface AuthResponse {
+  userId: number;
+  token: string;
+  role: 'CLIENTE' | 'PROVEEDOR';
+}

--- a/src/interfaces/auth/LoginRequest.ts
+++ b/src/interfaces/auth/LoginRequest.ts
@@ -1,1 +1,4 @@
-export interface LoginRequest {}
+export interface LoginRequest {
+  email: string;
+  password: string;
+}

--- a/src/interfaces/auth/RegisterClienteRequest.ts
+++ b/src/interfaces/auth/RegisterClienteRequest.ts
@@ -1,0 +1,7 @@
+export interface RegisterClienteRequest {
+  nombre: string;
+  apellido: string;
+  email: string;
+  telefono: string;
+  password: string;
+}

--- a/src/interfaces/auth/RegisterProveedorRequest.ts
+++ b/src/interfaces/auth/RegisterProveedorRequest.ts
@@ -1,0 +1,7 @@
+export interface RegisterProveedorRequest {
+  nombre: string;
+  email: string;
+  password: string;
+  descripcion: string;
+  telefono: string;
+}

--- a/src/interfaces/auth/RegisterRequest.ts
+++ b/src/interfaces/auth/RegisterRequest.ts
@@ -1,1 +1,7 @@
-export interface RegisterRequest {}
+import type { AuthResponse } from './AuthResponse';
+export interface RegisterRequest {
+  name: string;
+  email: string;
+  password: string;
+  role: AuthResponse['role'];
+}

--- a/src/interfaces/auth/RegisterRequest.ts
+++ b/src/interfaces/auth/RegisterRequest.ts
@@ -1,7 +1,0 @@
-import type { AuthResponse } from './AuthResponse';
-export interface RegisterRequest {
-  name: string;
-  email: string;
-  password: string;
-  role: AuthResponse['role'];
-}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { AuthProvider } from "@contexts/AuthContext";
 import { router } from "@router/routes";
+import { attachInterceptors } from "@services/axiosInstance";
 import "@styles/App.css";
 import "@styles/index.css";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
+
+attachInterceptors();
 
 createRoot(document.getElementById("root")!).render(
 	<StrictMode>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 
-attachInterceptors();
+attachInterceptors(router.navigate);
 
 createRoot(document.getElementById("root")!).render(
 	<StrictMode>

--- a/src/pages/AllReservationsPage.tsx
+++ b/src/pages/AllReservationsPage.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+import { getAllReservas, Reserva } from '../services/reservas';
+import ReservationCard from '../components/ReservationCard';
+
+export default function AllReservationsPage() {
+  const [list, setList] = useState<Reserva[]>([]);
+
+  useEffect(() => {
+    getAllReservas().then(setList);
+  }, []);
+
+  return (
+    <div className="p-4 space-y-2">
+      {list.map(r => (
+        <ReservationCard key={r.id} reserva={r} />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/ClientDashboardPage.tsx
+++ b/src/pages/ClientDashboardPage.tsx
@@ -1,0 +1,32 @@
+import { Link } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import { useEffect, useState } from 'react';
+import { getClienteReservas } from '../services/reservas';
+
+export default function ClientDashboardPage() {
+  const { userId } = useAuth();
+  const [active, setActive] = useState(0);
+
+  useEffect(() => {
+    if (userId) {
+      getClienteReservas(userId).then(list => {
+        setActive(list.filter(r => r.estado !== 'CANCELADA').length);
+      });
+    }
+  }, [userId]);
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Bienvenido</h1>
+      <p>Reservas activas: {active}</p>
+      <nav className="space-x-4">
+        <Link to="/cliente/servicios" className="underline text-blue-600">
+          Buscar Servicios
+        </Link>
+        <Link to="/cliente/reservas" className="underline text-blue-600">
+          Mis Reservas
+        </Link>
+      </nav>
+    </div>
+  );
+}

--- a/src/pages/ClientReservationsPage.tsx
+++ b/src/pages/ClientReservationsPage.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { getClienteReservas, Reserva } from '../services/reservas';
+import { useAuth } from '../contexts/AuthContext';
+import ReservationCard from '../components/ReservationCard';
+
+export default function ClientReservationsPage() {
+  const { userId } = useAuth();
+  const [list, setList] = useState<Reserva[]>([]);
+
+  useEffect(() => {
+    getClienteReservas(userId).then(setList);
+  }, [userId]);
+
+  return (
+    <div className="p-4 space-y-2">
+      {list.map(r => (
+        <ReservationCard key={r.id} reserva={r} />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/ClientReservationsPage.tsx
+++ b/src/pages/ClientReservationsPage.tsx
@@ -4,12 +4,12 @@ import { useAuth } from '../contexts/AuthContext';
 import ReservationCard from '../components/ReservationCard';
 
 export default function ClientReservationsPage() {
-  const { userId } = useAuth();
+  const { id } = useAuth();
   const [list, setList] = useState<Reserva[]>([]);
 
   useEffect(() => {
-    getClienteReservas(userId).then(setList);
-  }, [userId]);
+    getClienteReservas(id).then(setList);
+  }, [id]);
 
   return (
     <div className="p-4 space-y-2">

--- a/src/pages/ClientReservationsPage.tsx
+++ b/src/pages/ClientReservationsPage.tsx
@@ -4,14 +4,14 @@ import { useAuth } from '../contexts/AuthContext';
 import ReservationCard from '../components/ReservationCard';
 
 export default function ClientReservationsPage() {
-  const { id } = useAuth();
+  const { userId } = useAuth();
   const [list, setList] = useState<Reserva[]>([]);
 
   useEffect(() => {
-    if (id) {
-      getClienteReservas(id).then(setList);
+    if (userId) {
+      getClienteReservas(userId).then(setList);
     }
-  }, [id]);
+  }, [userId]);
 
   return (
     <div className="p-4 space-y-2">

--- a/src/pages/ClientReservationsPage.tsx
+++ b/src/pages/ClientReservationsPage.tsx
@@ -8,7 +8,9 @@ export default function ClientReservationsPage() {
   const [list, setList] = useState<Reserva[]>([]);
 
   useEffect(() => {
-    getClienteReservas(id).then(setList);
+    if (id) {
+      getClienteReservas(id).then(setList);
+    }
   }, [id]);
 
   return (

--- a/src/pages/ClientServicesPage.tsx
+++ b/src/pages/ClientServicesPage.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+import { searchServicios, Servicio } from '../services/servicios';
+import ServiceCard from '../components/ServiceCard';
+
+export default function ClientServicesPage() {
+  const [list, setList] = useState<Servicio[]>([]);
+
+  useEffect(() => {
+    searchServicios({}).then(setList);
+  }, []);
+
+  return (
+    <div className="p-4 space-y-2">
+      {list.map(s => (
+        <ServiceCard key={s.id} servicio={s} />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/CreateReservationPage.tsx
+++ b/src/pages/CreateReservationPage.tsx
@@ -1,0 +1,49 @@
+import { FormEvent, useState, useEffect } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import { createReserva } from '../services/reservas';
+import { searchServicios, Servicio } from '../services/servicios';
+import Input from '../components/Input';
+import Button from '../components/Button';
+
+export default function CreateReservationPage() {
+  const { userId } = useAuth();
+  const [servicioId, setServicioId] = useState(0);
+  const [fecha, setFecha] = useState('');
+  const [direccion, setDireccion] = useState('');
+  const [services, setServices] = useState<Servicio[]>([]);
+
+  useEffect(() => {
+    searchServicios({}).then(setServices);
+  }, []);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!userId) return;
+    await createReserva(userId, { fechaReserva: fecha, direccion, servicioId });
+    setFecha('');
+    setDireccion('');
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 space-y-2">
+      <label className="flex flex-col gap-1">
+        <span>Servicio</span>
+        <select
+          value={servicioId}
+          onChange={e => setServicioId(Number(e.target.value))}
+          className="border p-2 rounded"
+        >
+          <option value="0">Seleccione</option>
+          {services.map(s => (
+            <option key={s.id} value={s.id}>
+              {s.nombre}
+            </option>
+          ))}
+        </select>
+      </label>
+      <Input label="Fecha" type="datetime-local" value={fecha} onChange={e => setFecha(e.target.value)} />
+      <Input label="Dirección" value={direccion} onChange={e => setDireccion(e.target.value)} />
+      <Button type="submit">Reservar</Button>
+    </form>
+  );
+}

--- a/src/pages/CreateReviewPage.tsx
+++ b/src/pages/CreateReviewPage.tsx
@@ -1,0 +1,34 @@
+import { FormEvent, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import { createResena } from '../services/resenas';
+import Input from '../components/Input';
+import Button from '../components/Button';
+
+export default function CreateReviewPage() {
+  const { servicioId } = useParams();
+  const { userId } = useAuth();
+  const [comentario, setComentario] = useState('');
+  const [calificacion, setCalificacion] = useState(5);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!servicioId || !userId) return;
+    await createResena({
+      servicioId: Number(servicioId),
+      clienteId: userId,
+      comentario,
+      calificacion,
+      fecha: new Date().toISOString(),
+    });
+    setComentario('');
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 space-y-2">
+      <Input label="Comentario" value={comentario} onChange={e => setComentario(e.target.value)} />
+      <Input label="Calificación" type="number" value={calificacion} onChange={e => setCalificacion(Number(e.target.value))} />
+      <Button type="submit">Enviar</Button>
+    </form>
+  );
+}

--- a/src/pages/CreateServicePage.tsx
+++ b/src/pages/CreateServicePage.tsx
@@ -1,0 +1,38 @@
+import { FormEvent, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import { addServicio } from '../services/proveedores';
+import Input from '../components/Input';
+import Button from '../components/Button';
+
+export default function CreateServicePage() {
+  const { userId } = useAuth();
+  const [nombre, setNombre] = useState('');
+  const [descripcion, setDescripcion] = useState('');
+  const [precio, setPrecio] = useState('');
+  const [categoria, setCategoria] = useState('');
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!userId) return;
+    await addServicio(userId, {
+      nombre,
+      descripcion,
+      precio: Number(precio),
+      categoria,
+    });
+    setNombre('');
+    setDescripcion('');
+    setPrecio('');
+    setCategoria('');
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 space-y-2">
+      <Input label="Nombre" value={nombre} onChange={e => setNombre(e.target.value)} />
+      <Input label="Descripción" value={descripcion} onChange={e => setDescripcion(e.target.value)} />
+      <Input label="Precio" value={precio} onChange={e => setPrecio(e.target.value)} />
+      <Input label="Categoría" value={categoria} onChange={e => setCategoria(e.target.value)} />
+      <Button type="submit">Crear</Button>
+    </form>
+  );
+}

--- a/src/pages/EditServicePage.tsx
+++ b/src/pages/EditServicePage.tsx
@@ -1,0 +1,28 @@
+import { FormEvent, useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { updateServicio, Servicio } from '../services/servicios';
+import Input from '../components/Input';
+import Button from '../components/Button';
+
+export default function EditServicePage() {
+  const { servicioId } = useParams();
+  const [data, setData] = useState<Partial<Servicio>>({});
+
+  useEffect(() => {}, [servicioId]);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!servicioId) return;
+    await updateServicio(Number(servicioId), data);
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 space-y-2">
+      <Input label="Nombre" value={data.nombre || ''} onChange={e => setData({ ...data, nombre: e.target.value })} />
+      <Input label="Descripción" value={data.descripcion || ''} onChange={e => setData({ ...data, descripcion: e.target.value })} />
+      <Input label="Precio" value={data.precio?.toString() || ''} onChange={e => setData({ ...data, precio: Number(e.target.value) })} />
+      <Input label="Categoría" value={data.categoria || ''} onChange={e => setData({ ...data, categoria: e.target.value })} />
+      <Button type="submit">Guardar</Button>
+    </form>
+  );
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,23 @@
+import { FormEvent, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import Input from '../components/Input';
+import Button from '../components/Button';
+
+export default function LoginPage() {
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    await login({ email, password });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4">
+      <Input label="Email" value={email} onChange={e => setEmail(e.target.value)} />
+      <Input label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} />
+      <Button type="submit">Login</Button>
+    </form>
+  );
+}

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,12 +1,8 @@
 export default function NotFoundPage() {
-	return (
-		<>
-			<h1 id="notFound" className="text-2xl">
-				404 - Page Not Found
-			</h1>
-			<button id="historyBack" onClick={}>
-				Back
-			</button>
-		</>
-	);
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl">404 - Page Not Found</h1>
+      <button onClick={() => history.back()} className="underline text-blue-600">Back</button>
+    </div>
+  );
 }

--- a/src/pages/ProviderDashboardPage.tsx
+++ b/src/pages/ProviderDashboardPage.tsx
@@ -1,0 +1,19 @@
+import { Link } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+
+export default function ProviderDashboardPage() {
+  useAuth();
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Panel del Proveedor</h1>
+      <nav className="space-x-4">
+        <Link to="/proveedor/servicios" className="underline text-blue-600">
+          Mis Servicios
+        </Link>
+        <Link to="/proveedor/reservas" className="underline text-blue-600">
+          Reservas
+        </Link>
+      </nav>
+    </div>
+  );
+}

--- a/src/pages/ProviderReservationsPage.tsx
+++ b/src/pages/ProviderReservationsPage.tsx
@@ -8,7 +8,9 @@ export default function ProviderReservationsPage() {
   const [list, setList] = useState<Reserva[]>([]);
 
   useEffect(() => {
-    getProveedorReservas(id).then(setList);
+    if (id) {
+      getProveedorReservas(id).then(setList);
+    }
   }, [id]);
 
   return (

--- a/src/pages/ProviderReservationsPage.tsx
+++ b/src/pages/ProviderReservationsPage.tsx
@@ -4,14 +4,14 @@ import { useAuth } from '../contexts/AuthContext';
 import ReservationCard from '../components/ReservationCard';
 
 export default function ProviderReservationsPage() {
-  const { id } = useAuth();
+  const { userId } = useAuth();
   const [list, setList] = useState<Reserva[]>([]);
 
   useEffect(() => {
-    if (id) {
-      getProveedorReservas(id).then(setList);
+    if (userId) {
+      getProveedorReservas(userId).then(setList);
     }
-  }, [id]);
+  }, [userId]);
 
   return (
     <div className="p-4 space-y-2">

--- a/src/pages/ProviderReservationsPage.tsx
+++ b/src/pages/ProviderReservationsPage.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { getProveedorReservas, Reserva } from '../services/reservas';
+import { useAuth } from '../contexts/AuthContext';
+import ReservationCard from '../components/ReservationCard';
+
+export default function ProviderReservationsPage() {
+  const { userId } = useAuth();
+  const [list, setList] = useState<Reserva[]>([]);
+
+  useEffect(() => {
+    getProveedorReservas(userId).then(setList);
+  }, [userId]);
+
+  return (
+    <div className="p-4 space-y-2">
+      {list.map(r => (
+        <ReservationCard key={r.id} reserva={r} />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/ProviderReservationsPage.tsx
+++ b/src/pages/ProviderReservationsPage.tsx
@@ -4,12 +4,12 @@ import { useAuth } from '../contexts/AuthContext';
 import ReservationCard from '../components/ReservationCard';
 
 export default function ProviderReservationsPage() {
-  const { userId } = useAuth();
+  const { id } = useAuth();
   const [list, setList] = useState<Reserva[]>([]);
 
   useEffect(() => {
-    getProveedorReservas(userId).then(setList);
-  }, [userId]);
+    getProveedorReservas(id).then(setList);
+  }, [id]);
 
   return (
     <div className="p-4 space-y-2">

--- a/src/pages/ProviderReviewsPage.tsx
+++ b/src/pages/ProviderReviewsPage.tsx
@@ -1,0 +1,32 @@
+import { useAuth } from '../contexts/AuthContext';
+import { useEffect, useState } from 'react';
+import { searchServicios } from '../services/servicios';
+import { getResenas, Resena } from '../services/resenas';
+import ReviewCard from '../components/ReviewCard';
+
+export default function ProviderReviewsPage() {
+  const { userId } = useAuth();
+  const [reviews, setReviews] = useState<Resena[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      if (!userId) return;
+      const servicios = await searchServicios({ proveedorId: userId });
+      const all: Resena[] = [];
+      for (const s of servicios) {
+        const r = await getResenas(s.id);
+        all.push(...r);
+      }
+      setReviews(all);
+    }
+    load();
+  }, [userId]);
+
+  return (
+    <div className="p-4 space-y-2">
+      {reviews.map(r => (
+        <ReviewCard key={r.id} resena={r} />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/ProviderServicesPage.tsx
+++ b/src/pages/ProviderServicesPage.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { searchServicios, Servicio } from '../services/servicios';
+import ServiceCard from '../components/ServiceCard';
+import { useAuth } from '../contexts/AuthContext';
+
+export default function ProviderServicesPage() {
+  const { userId } = useAuth();
+  const [list, setList] = useState<Servicio[]>([]);
+
+  useEffect(() => {
+    searchServicios({ proveedorId: userId }).then(setList);
+  }, [userId]);
+
+  return (
+    <div className="p-4 space-y-2">
+      {list.map(s => (
+        <ServiceCard key={s.id} servicio={s} />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/ProviderServicesPage.tsx
+++ b/src/pages/ProviderServicesPage.tsx
@@ -4,12 +4,12 @@ import ServiceCard from '../components/ServiceCard';
 import { useAuth } from '../contexts/AuthContext';
 
 export default function ProviderServicesPage() {
-  const { id } = useAuth();
+  const { userId } = useAuth();
   const [list, setList] = useState<Servicio[]>([]);
 
   useEffect(() => {
-    searchServicios({ proveedorId: id }).then(setList);
-  }, [id]);
+    searchServicios({ proveedorId: userId }).then(setList);
+  }, [userId]);
 
   return (
     <div className="p-4 space-y-2">

--- a/src/pages/ProviderServicesPage.tsx
+++ b/src/pages/ProviderServicesPage.tsx
@@ -4,12 +4,12 @@ import ServiceCard from '../components/ServiceCard';
 import { useAuth } from '../contexts/AuthContext';
 
 export default function ProviderServicesPage() {
-  const { userId } = useAuth();
+  const { id } = useAuth();
   const [list, setList] = useState<Servicio[]>([]);
 
   useEffect(() => {
-    searchServicios({ proveedorId: userId }).then(setList);
-  }, [userId]);
+    searchServicios({ proveedorId: id }).then(setList);
+  }, [id]);
 
   return (
     <div className="p-4 space-y-2">

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -5,21 +5,35 @@ import Button from '../components/Button';
 
 export default function RegisterPage() {
   const { register } = useAuth();
-  const [name, setName] = useState('');
+  const [nombre, setNombre] = useState('');
+  const [apellido, setApellido] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [telefono, setTelefono] = useState('');
+  const [descripcion, setDescripcion] = useState('');
   const [role, setRole] = useState<'CLIENTE' | 'PROVEEDOR'>('CLIENTE');
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    await register({ name, email, password, role });
+    if (role === 'CLIENTE') {
+      await register({ nombre, apellido, email, telefono, password, role });
+    } else {
+      await register({ nombre, email, password, descripcion, telefono, role });
+    }
   }
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4">
-      <Input label="Nombre" value={name} onChange={e => setName(e.target.value)} />
+      <Input label="Nombre" value={nombre} onChange={e => setNombre(e.target.value)} />
+      {role === 'CLIENTE' && (
+        <Input label="Apellido" value={apellido} onChange={e => setApellido(e.target.value)} />
+      )}
       <Input label="Email" value={email} onChange={e => setEmail(e.target.value)} />
       <Input label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} />
+      <Input label="Teléfono" value={telefono} onChange={e => setTelefono(e.target.value)} />
+      {role === 'PROVEEDOR' && (
+        <Input label="Descripción" value={descripcion} onChange={e => setDescripcion(e.target.value)} />
+      )}
       <label className="flex gap-2 items-center">
         <span>Rol</span>
         <select value={role} onChange={e => setRole(e.target.value as 'CLIENTE' | 'PROVEEDOR')} className="border p-2 rounded">

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -1,0 +1,33 @@
+import { FormEvent, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import Input from '../components/Input';
+import Button from '../components/Button';
+
+export default function RegisterPage() {
+  const { register } = useAuth();
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [role, setRole] = useState<'CLIENTE' | 'PROVEEDOR'>('CLIENTE');
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    await register({ name, email, password, role });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4">
+      <Input label="Nombre" value={name} onChange={e => setName(e.target.value)} />
+      <Input label="Email" value={email} onChange={e => setEmail(e.target.value)} />
+      <Input label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} />
+      <label className="flex gap-2 items-center">
+        <span>Rol</span>
+        <select value={role} onChange={e => setRole(e.target.value as 'CLIENTE' | 'PROVEEDOR')} className="border p-2 rounded">
+          <option value="CLIENTE">Cliente</option>
+          <option value="PROVEEDOR">Proveedor</option>
+        </select>
+      </label>
+      <Button type="submit">Register</Button>
+    </form>
+  );
+}

--- a/src/pages/SearchServicesPage.tsx
+++ b/src/pages/SearchServicesPage.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState, FormEvent } from 'react';
+import { searchServicios, Servicio } from '../services/servicios';
+import ServiceCard from '../components/ServiceCard';
+import Input from '../components/Input';
+import Button from '../components/Button';
+
+export default function SearchServicesPage() {
+  const [list, setList] = useState<Servicio[]>([]);
+  const [categoria, setCategoria] = useState('');
+  const [direccion, setDireccion] = useState('');
+  const [precioMin, setPrecioMin] = useState('');
+  const [precioMax, setPrecioMax] = useState('');
+  const [calificacionMin, setCalificacionMin] = useState('');
+
+  function fetchData() {
+    searchServicios({
+      categoria: categoria || undefined,
+      direccion: direccion || undefined,
+      precioMin: precioMin ? Number(precioMin) : undefined,
+      precioMax: precioMax ? Number(precioMax) : undefined,
+      calificacionMin: calificacionMin ? Number(calificacionMin) : undefined,
+    }).then(setList);
+  }
+
+  useEffect(() => {
+    fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    fetchData();
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <form onSubmit={handleSubmit} className="flex flex-wrap gap-2">
+        <Input label="Categoria" value={categoria} onChange={e => setCategoria(e.target.value)} />
+        <Input label="Dirección" value={direccion} onChange={e => setDireccion(e.target.value)} />
+        <Input label="Precio Min" value={precioMin} onChange={e => setPrecioMin(e.target.value)} />
+        <Input label="Precio Max" value={precioMax} onChange={e => setPrecioMax(e.target.value)} />
+        <Input label="Calificación Min" value={calificacionMin} onChange={e => setCalificacionMin(e.target.value)} />
+        <Button type="submit">Buscar</Button>
+      </form>
+      <div className="space-y-2">
+        {list.map(s => (
+          <ServiceCard key={s.id} servicio={s} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/ServiceReviewsPage.tsx
+++ b/src/pages/ServiceReviewsPage.tsx
@@ -19,8 +19,14 @@ export default function ServiceReviewsPage() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!servicioId) return;
-    const res = await createResena({ servicioId: Number(servicioId), clienteId: id, comentario, calificacion, fecha: new Date().toISOString() });
+    if (!servicioId || !id) return;
+    const res = await createResena({
+      servicioId: Number(servicioId),
+      clienteId: id,
+      comentario,
+      calificacion,
+      fecha: new Date().toISOString(),
+    });
     setList([...list, res]);
     setComentario('');
   }

--- a/src/pages/ServiceReviewsPage.tsx
+++ b/src/pages/ServiceReviewsPage.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { getResenas, createResena, Resena } from '../services/resenas';
+import ReviewCard from '../components/ReviewCard';
+import { useAuth } from '../contexts/AuthContext';
+import Input from '../components/Input';
+import Button from '../components/Button';
+
+export default function ServiceReviewsPage() {
+  const { servicioId } = useParams();
+  const { userId } = useAuth();
+  const [list, setList] = useState<Resena[]>([]);
+  const [comentario, setComentario] = useState('');
+  const [calificacion, setCalificacion] = useState(5);
+
+  useEffect(() => {
+    if (servicioId) getResenas(Number(servicioId)).then(setList);
+  }, [servicioId]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!servicioId) return;
+    const res = await createResena({ servicioId: Number(servicioId), clienteId: userId, comentario, calificacion });
+    setList([...list, res]);
+    setComentario('');
+  }
+
+  return (
+    <div className="p-4 space-y-2">
+      {list.map(r => (
+        <ReviewCard key={r.id} resena={r} />
+      ))}
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <Input label="Comentario" value={comentario} onChange={e => setComentario(e.target.value)} />
+        <Input label="Calificación" type="number" value={calificacion} onChange={e => setCalificacion(Number(e.target.value))} />
+        <Button type="submit">Enviar</Button>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/ServiceReviewsPage.tsx
+++ b/src/pages/ServiceReviewsPage.tsx
@@ -8,7 +8,7 @@ import Button from '../components/Button';
 
 export default function ServiceReviewsPage() {
   const { servicioId } = useParams();
-  const { id } = useAuth();
+  const { userId } = useAuth();
   const [list, setList] = useState<Resena[]>([]);
   const [comentario, setComentario] = useState('');
   const [calificacion, setCalificacion] = useState(5);
@@ -19,10 +19,10 @@ export default function ServiceReviewsPage() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!servicioId || !id) return;
+    if (!servicioId || !userId) return;
     const res = await createResena({
       servicioId: Number(servicioId),
-      clienteId: id,
+      clienteId: userId,
       comentario,
       calificacion,
       fecha: new Date().toISOString(),

--- a/src/pages/ServiceReviewsPage.tsx
+++ b/src/pages/ServiceReviewsPage.tsx
@@ -8,7 +8,7 @@ import Button from '../components/Button';
 
 export default function ServiceReviewsPage() {
   const { servicioId } = useParams();
-  const { userId } = useAuth();
+  const { id } = useAuth();
   const [list, setList] = useState<Resena[]>([]);
   const [comentario, setComentario] = useState('');
   const [calificacion, setCalificacion] = useState(5);
@@ -20,7 +20,7 @@ export default function ServiceReviewsPage() {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!servicioId) return;
-    const res = await createResena({ servicioId: Number(servicioId), clienteId: userId, comentario, calificacion });
+    const res = await createResena({ servicioId: Number(servicioId), clienteId: id, comentario, calificacion, fecha: new Date().toISOString() });
     setList([...list, res]);
     setComentario('');
   }

--- a/src/pages/ServiceSchedulePage.tsx
+++ b/src/pages/ServiceSchedulePage.tsx
@@ -1,0 +1,33 @@
+import { FormEvent, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { setHorarios, HorarioReq } from '../services/servicios';
+import Input from '../components/Input';
+import Button from '../components/Button';
+
+export default function ServiceSchedulePage() {
+  const { servicioId } = useParams();
+  const [horarios, setData] = useState<HorarioReq[]>([{ diaSemana: '', horaInicio: '', horaFin: '' }]);
+
+  function handleChange(index: number, field: keyof HorarioReq, value: string) {
+    setData(h => h.map((it, i) => (i === index ? { ...it, [field]: value } : it)));
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!servicioId) return;
+    await setHorarios(Number(servicioId), horarios);
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 space-y-2">
+      {horarios.map((h, idx) => (
+        <div key={idx} className="flex gap-2">
+          <Input label="Día" value={h.diaSemana} onChange={e => handleChange(idx, 'diaSemana', e.target.value)} />
+          <Input label="Inicio" value={h.horaInicio} onChange={e => handleChange(idx, 'horaInicio', e.target.value)} />
+          <Input label="Fin" value={h.horaFin} onChange={e => handleChange(idx, 'horaFin', e.target.value)} />
+        </div>
+      ))}
+      <Button type="submit">Guardar</Button>
+    </form>
+  );
+}

--- a/src/router/ProtectedRoute.tsx
+++ b/src/router/ProtectedRoute.tsx
@@ -1,0 +1,10 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+
+export function ProtectedRoute({ allowedRoles }: { allowedRoles: Array<'CLIENTE' | 'PROVEEDOR'> }) {
+  const auth = useAuth();
+  if (!auth.token || !auth.role || !allowedRoles.includes(auth.role)) {
+    return <Navigate to="/login" />;
+  }
+  return <Outlet />;
+}

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -1,0 +1,44 @@
+import { createBrowserRouter, RouteObject } from 'react-router-dom';
+import App from '../App';
+import LoginPage from '../pages/LoginPage';
+import RegisterPage from '../pages/RegisterPage';
+import ClientServicesPage from '../pages/ClientServicesPage';
+import ProviderServicesPage from '../pages/ProviderServicesPage';
+import ClientReservationsPage from '../pages/ClientReservationsPage';
+import ProviderReservationsPage from '../pages/ProviderReservationsPage';
+import AllReservationsPage from '../pages/AllReservationsPage';
+import ServiceReviewsPage from '../pages/ServiceReviewsPage';
+import { ProtectedRoute } from './ProtectedRoute';
+import NotFoundPage from '../pages/NotFoundPage';
+
+const clienteRoutes: RouteObject[] = [
+  { path: '/cliente/servicios', element: <ClientServicesPage /> },
+  { path: '/cliente/reservas', element: <ClientReservationsPage /> },
+];
+
+const proveedorRoutes: RouteObject[] = [
+  { path: '/proveedor/servicios', element: <ProviderServicesPage /> },
+  { path: '/proveedor/reservas', element: <ProviderReservationsPage /> },
+];
+
+export const router = createBrowserRouter([
+  { path: '/login', element: <LoginPage /> },
+  { path: '/register', element: <RegisterPage /> },
+  {
+    element: <App />,
+    children: [
+      {
+        element: <ProtectedRoute allowedRoles={['CLIENTE']} />,
+        children: clienteRoutes,
+      },
+      {
+        element: <ProtectedRoute allowedRoles={['PROVEEDOR']} />,
+        children: proveedorRoutes,
+      },
+      { path: '/reservas', element: <ProtectedRoute allowedRoles={['PROVEEDOR']} /> },
+      { path: '/admin/reservas', element: <AllReservationsPage /> },
+      { path: '/servicios/:servicioId/resenas', element: <ServiceReviewsPage /> },
+    ],
+  },
+  { path: '*', element: <NotFoundPage /> },
+]);

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -8,17 +8,35 @@ import ClientReservationsPage from '../pages/ClientReservationsPage';
 import ProviderReservationsPage from '../pages/ProviderReservationsPage';
 import AllReservationsPage from '../pages/AllReservationsPage';
 import ServiceReviewsPage from '../pages/ServiceReviewsPage';
+import ClientDashboardPage from '../pages/ClientDashboardPage';
+import ProviderDashboardPage from '../pages/ProviderDashboardPage';
+import CreateReservationPage from '../pages/CreateReservationPage';
+import SearchServicesPage from '../pages/SearchServicesPage';
+import CreateReviewPage from '../pages/CreateReviewPage';
+import CreateServicePage from '../pages/CreateServicePage';
+import EditServicePage from '../pages/EditServicePage';
+import ServiceSchedulePage from '../pages/ServiceSchedulePage';
+import ProviderReviewsPage from '../pages/ProviderReviewsPage';
 import { ProtectedRoute } from './ProtectedRoute';
 import NotFoundPage from '../pages/NotFoundPage';
 
 const clienteRoutes: RouteObject[] = [
+  { path: '/cliente/dashboard', element: <ClientDashboardPage /> },
   { path: '/cliente/servicios', element: <ClientServicesPage /> },
   { path: '/cliente/reservas', element: <ClientReservationsPage /> },
+  { path: '/cliente/reservar', element: <CreateReservationPage /> },
+  { path: '/cliente/buscar', element: <SearchServicesPage /> },
+  { path: '/cliente/resenas/nuevo/:servicioId', element: <CreateReviewPage /> },
 ];
 
 const proveedorRoutes: RouteObject[] = [
+  { path: '/proveedor/dashboard', element: <ProviderDashboardPage /> },
   { path: '/proveedor/servicios', element: <ProviderServicesPage /> },
+  { path: '/proveedor/servicios/nuevo', element: <CreateServicePage /> },
+  { path: '/proveedor/servicios/:servicioId/editar', element: <EditServicePage /> },
+  { path: '/proveedor/servicios/:servicioId/horarios', element: <ServiceSchedulePage /> },
   { path: '/proveedor/reservas', element: <ProviderReservationsPage /> },
+  { path: '/proveedor/resenas', element: <ProviderReviewsPage /> },
 ];
 
 export const router = createBrowserRouter([

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -35,7 +35,6 @@ export const router = createBrowserRouter([
         element: <ProtectedRoute allowedRoles={['PROVEEDOR']} />,
         children: proveedorRoutes,
       },
-      { path: '/reservas', element: <ProtectedRoute allowedRoles={['PROVEEDOR']} /> },
       { path: '/admin/reservas', element: <AllReservationsPage /> },
       { path: '/servicios/:servicioId/resenas', element: <ServiceReviewsPage /> },
     ],

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, RouteObject } from 'react-router-dom';
+import { createBrowserRouter, Navigate, RouteObject } from 'react-router-dom';
 import App from '../App';
 import LoginPage from '../pages/LoginPage';
 import RegisterPage from '../pages/RegisterPage';
@@ -27,6 +27,7 @@ export const router = createBrowserRouter([
   {
     element: <App />,
     children: [
+      { index: true, element: <Navigate to="/login" replace /> },
       {
         element: <ProtectedRoute allowedRoles={['CLIENTE']} />,
         children: clienteRoutes,

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,34 @@
+import { axiosInstance } from './axiosInstance';
+
+export interface AuthResponse {
+  userId: number;
+  token: string;
+  role: 'CLIENTE' | 'PROVEEDOR';
+}
+
+export interface LoginReq {
+  email: string;
+  password: string;
+}
+
+export interface RegisterReq {
+  name: string;
+  email: string;
+  password: string;
+  role: AuthResponse['role'];
+}
+
+export async function login(req: LoginReq): Promise<AuthResponse> {
+  const { data } = await axiosInstance.post<AuthResponse>('/auth/login', req);
+  return data;
+}
+
+export async function registerCliente(r: RegisterReq): Promise<AuthResponse> {
+  const { data } = await axiosInstance.post<AuthResponse>('/auth/register/cliente', r);
+  return data;
+}
+
+export async function registerProveedor(r: RegisterReq): Promise<AuthResponse> {
+  const { data } = await axiosInstance.post<AuthResponse>('/auth/register/proveedor', r);
+  return data;
+}

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,7 +1,9 @@
 import { axiosInstance } from './axiosInstance';
+import type { RegisterClienteRequest } from '../interfaces/auth/RegisterClienteRequest';
+import type { RegisterProveedorRequest } from '../interfaces/auth/RegisterProveedorRequest';
 
 export interface AuthResponse {
-  userId: number;
+  id: number;
   token: string;
   role: 'CLIENTE' | 'PROVEEDOR';
 }
@@ -11,24 +13,18 @@ export interface LoginReq {
   password: string;
 }
 
-export interface RegisterReq {
-  name: string;
-  email: string;
-  password: string;
-  role: AuthResponse['role'];
-}
 
 export async function login(req: LoginReq): Promise<AuthResponse> {
   const { data } = await axiosInstance.post<AuthResponse>('/auth/login', req);
   return data;
 }
 
-export async function registerCliente(r: RegisterReq): Promise<AuthResponse> {
+export async function registerCliente(r: RegisterClienteRequest): Promise<AuthResponse> {
   const { data } = await axiosInstance.post<AuthResponse>('/auth/register/cliente', r);
   return data;
 }
 
-export async function registerProveedor(r: RegisterReq): Promise<AuthResponse> {
+export async function registerProveedor(r: RegisterProveedorRequest): Promise<AuthResponse> {
   const { data } = await axiosInstance.post<AuthResponse>('/auth/register/proveedor', r);
   return data;
 }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,12 +1,7 @@
 import { axiosInstance } from './axiosInstance';
 import type { RegisterClienteRequest } from '../interfaces/auth/RegisterClienteRequest';
 import type { RegisterProveedorRequest } from '../interfaces/auth/RegisterProveedorRequest';
-
-export interface AuthResponse {
-  id: number;
-  token: string;
-  role: 'CLIENTE' | 'PROVEEDOR';
-}
+import type { AuthResponse } from '../interfaces/auth/AuthResponse';
 
 export interface LoginReq {
   email: string;

--- a/src/services/auth/login.ts
+++ b/src/services/auth/login.ts
@@ -1,3 +1,0 @@
-import { LoginRequest } from "@interfaces/auth/LoginRequest";
-
-export async function login(loginRequest: LoginRequest) {}

--- a/src/services/auth/register.ts
+++ b/src/services/auth/register.ts
@@ -1,3 +1,0 @@
-import { RegisterRequest } from "@interfaces/auth/RegisterRequest";
-
-export async function register(registerRequest: RegisterRequest) {}

--- a/src/services/axiosInstance.ts
+++ b/src/services/axiosInstance.ts
@@ -1,0 +1,28 @@
+import axios from 'axios';
+import { getAuthToken } from '../utils/authHelpers';
+import { externalLogout } from '../contexts/AuthContext';
+import { NavigateFunction } from 'react-router-dom';
+
+export const axiosInstance = axios.create({
+  baseURL: '/api',
+  headers: { 'Content-Type': 'application/json' },
+});
+
+export function attachInterceptors(navigate?: NavigateFunction) {
+  axiosInstance.interceptors.request.use(cfg => {
+    const token = getAuthToken();
+    if (token) cfg.headers!['Authorization'] = `Bearer ${token}`;
+    return cfg;
+  });
+
+  axiosInstance.interceptors.response.use(
+    r => r,
+    err => {
+      if (err.response?.status === 401) {
+        externalLogout();
+        navigate?.('/login');
+      }
+      return Promise.reject(err);
+    },
+  );
+}

--- a/src/services/axiosInstance.ts
+++ b/src/services/axiosInstance.ts
@@ -4,7 +4,7 @@ import { externalLogout } from '../contexts/AuthContext';
 import { NavigateFunction } from 'react-router-dom';
 
 export const axiosInstance = axios.create({
-  baseURL: '/api',
+  baseURL: 'http://localhost:8081',
   headers: { 'Content-Type': 'application/json' },
 });
 

--- a/src/services/pagos.ts
+++ b/src/services/pagos.ts
@@ -9,6 +9,9 @@ export async function procesarPago(
   reservaId: number,
   body: PagoReq,
 ): Promise<{ success: boolean }> {
-  const { data } = await axiosInstance.post<{ success: boolean }>(`/pagos/${reservaId}`, body);
+  const { data } = await axiosInstance.post<{ success: boolean }>(
+    `/api/pagos/${reservaId}`,
+    body,
+  );
   return data;
 }

--- a/src/services/pagos.ts
+++ b/src/services/pagos.ts
@@ -1,6 +1,14 @@
 import { axiosInstance } from './axiosInstance';
 
-export async function procesarPago(reservaId: number): Promise<{ success: boolean }> {
-  const { data } = await axiosInstance.post<{ success: boolean }>(`/pagos/${reservaId}`);
+export interface PagoReq {
+  monto: number;
+  estado: string;
+}
+
+export async function procesarPago(
+  reservaId: number,
+  body: PagoReq,
+): Promise<{ success: boolean }> {
+  const { data } = await axiosInstance.post<{ success: boolean }>(`/pagos/${reservaId}`, body);
   return data;
 }

--- a/src/services/pagos.ts
+++ b/src/services/pagos.ts
@@ -1,0 +1,6 @@
+import { axiosInstance } from './axiosInstance';
+
+export async function procesarPago(reservaId: number): Promise<{ success: boolean }> {
+  const { data } = await axiosInstance.post<{ success: boolean }>(`/pagos/${reservaId}`);
+  return data;
+}

--- a/src/services/proveedores.ts
+++ b/src/services/proveedores.ts
@@ -1,0 +1,14 @@
+import { axiosInstance } from './axiosInstance';
+import type { Servicio } from './servicios';
+
+export interface CreateServicioReq {
+  nombre: string;
+  descripcion: string;
+  precio: number;
+  categoria: string;
+}
+
+export async function addServicio(proveedorId: number, body: CreateServicioReq): Promise<Servicio> {
+  const { data } = await axiosInstance.post<Servicio>(`/proveedores/${proveedorId}/servicios`, body);
+  return data;
+}

--- a/src/services/proveedores.ts
+++ b/src/services/proveedores.ts
@@ -8,7 +8,13 @@ export interface CreateServicioReq {
   categoria: string;
 }
 
-export async function addServicio(proveedorId: number, body: CreateServicioReq): Promise<Servicio> {
-  const { data } = await axiosInstance.post<Servicio>(`/proveedores/${proveedorId}/servicios`, body);
+export async function addServicio(
+  proveedorId: number,
+  body: CreateServicioReq,
+): Promise<Servicio> {
+  const { data } = await axiosInstance.post<Servicio>(
+    `/api/proveedores/${proveedorId}/servicios`,
+    body,
+  );
   return data;
 }

--- a/src/services/resenas.ts
+++ b/src/services/resenas.ts
@@ -18,11 +18,13 @@ export interface CreateResenaReq {
 }
 
 export async function createResena(body: CreateResenaReq): Promise<Resena> {
-  const { data } = await axiosInstance.post<Resena>('/resenas', body);
+  const { data } = await axiosInstance.post<Resena>('/api/resenas', body);
   return data;
 }
 
 export async function getResenas(servicioId: number): Promise<Resena[]> {
-  const { data } = await axiosInstance.get<Resena[]>(`/servicios/${servicioId}/resenas`);
+  const { data } = await axiosInstance.get<Resena[]>(
+    `/api/servicios/${servicioId}/resenas`,
+  );
   return data;
 }

--- a/src/services/resenas.ts
+++ b/src/services/resenas.ts
@@ -14,6 +14,7 @@ export interface CreateResenaReq {
   clienteId: number;
   calificacion: number;
   comentario: string;
+  fecha: string;
 }
 
 export async function createResena(body: CreateResenaReq): Promise<Resena> {

--- a/src/services/resenas.ts
+++ b/src/services/resenas.ts
@@ -1,0 +1,27 @@
+import { axiosInstance } from './axiosInstance';
+
+export interface Resena {
+  id: number;
+  servicioId: number;
+  clienteId: number;
+  calificacion: number;
+  comentario: string;
+  fecha: string;
+}
+
+export interface CreateResenaReq {
+  servicioId: number;
+  clienteId: number;
+  calificacion: number;
+  comentario: string;
+}
+
+export async function createResena(body: CreateResenaReq): Promise<Resena> {
+  const { data } = await axiosInstance.post<Resena>('/resenas', body);
+  return data;
+}
+
+export async function getResenas(servicioId: number): Promise<Resena[]> {
+  const { data } = await axiosInstance.get<Resena[]>(`/servicios/${servicioId}/resenas`);
+  return data;
+}

--- a/src/services/reservas.ts
+++ b/src/services/reservas.ts
@@ -4,7 +4,7 @@ export interface Reserva {
   id: number;
   fechaReserva: string;
   direccion: string;
-  estado: 'PENDIENTE' | 'COMPLETADA' | 'CANCELADA';
+  estado: 'PENDIENTE' | 'ACEPTADA' | 'COMPLETADA' | 'CANCELADA';
   clienteId: number;
   servicioId: number;
 }

--- a/src/services/reservas.ts
+++ b/src/services/reservas.ts
@@ -15,37 +15,58 @@ export interface CreateReservaReq {
   servicioId: number;
 }
 
-export async function createReserva(clienteId: number, body: CreateReservaReq): Promise<Reserva> {
-  const { data } = await axiosInstance.post<Reserva>(`/clientes/${clienteId}/reservas`, body);
+export async function createReserva(
+  clienteId: number,
+  body: CreateReservaReq,
+): Promise<Reserva> {
+  const { data } = await axiosInstance.post<Reserva>(
+    `/api/clientes/${clienteId}/reservas`,
+    body,
+  );
   return data;
 }
 
-export async function cancelReserva(clienteId: number, reservaId: number): Promise<Reserva> {
-  const { data } = await axiosInstance.patch<Reserva>(`/clientes/${clienteId}/reservas/${reservaId}/cancelar`);
+export async function cancelReserva(
+  clienteId: number,
+  reservaId: number,
+): Promise<Reserva> {
+  const { data } = await axiosInstance.patch<Reserva>(
+    `/api/clientes/${clienteId}/reservas/${reservaId}/cancelar`,
+  );
   return data;
 }
 
 export async function acceptReserva(reservaId: number): Promise<Reserva> {
-  const { data } = await axiosInstance.patch<Reserva>(`/reservas/${reservaId}/aceptar`);
+  const { data } = await axiosInstance.patch<Reserva>(
+    `/api/reservas/${reservaId}/aceptar`,
+  );
   return data;
 }
 
 export async function completeReserva(reservaId: number): Promise<Reserva> {
-  const { data } = await axiosInstance.patch<Reserva>(`/reservas/${reservaId}/completar`);
+  const { data } = await axiosInstance.patch<Reserva>(
+    `/api/reservas/${reservaId}/completar`,
+  );
   return data;
 }
 
 export async function getClienteReservas(clienteId: number): Promise<Reserva[]> {
-  const { data } = await axiosInstance.get<Reserva[]>(`/clientes/${clienteId}/reservas`);
+  const { data } = await axiosInstance.get<Reserva[]>(
+    `/api/clientes/${clienteId}/reservas`,
+  );
   return data;
 }
 
-export async function getProveedorReservas(proveedorId: number): Promise<Reserva[]> {
-  const { data } = await axiosInstance.get<Reserva[]>(`/proveedores/${proveedorId}/reservas`);
+export async function getProveedorReservas(
+  proveedorId: number,
+): Promise<Reserva[]> {
+  const { data } = await axiosInstance.get<Reserva[]>(
+    `/api/proveedores/${proveedorId}/reservas`,
+  );
   return data;
 }
 
 export async function getAllReservas(): Promise<Reserva[]> {
-  const { data } = await axiosInstance.get<Reserva[]>('/reservas');
+  const { data } = await axiosInstance.get<Reserva[]>('/api/reservas');
   return data;
 }

--- a/src/services/reservas.ts
+++ b/src/services/reservas.ts
@@ -1,0 +1,51 @@
+import { axiosInstance } from './axiosInstance';
+
+export interface Reserva {
+  id: number;
+  fechaReserva: string;
+  direccion: string;
+  estado: 'PENDIENTE' | 'COMPLETADA' | 'CANCELADA';
+  clienteId: number;
+  servicioId: number;
+}
+
+export interface CreateReservaReq {
+  fechaReserva: string;
+  direccion: string;
+  servicioId: number;
+}
+
+export async function createReserva(clienteId: number, body: CreateReservaReq): Promise<Reserva> {
+  const { data } = await axiosInstance.post<Reserva>(`/clientes/${clienteId}/reservas`, body);
+  return data;
+}
+
+export async function cancelReserva(clienteId: number, reservaId: number): Promise<Reserva> {
+  const { data } = await axiosInstance.patch<Reserva>(`/clientes/${clienteId}/reservas/${reservaId}/cancelar`);
+  return data;
+}
+
+export async function acceptReserva(reservaId: number): Promise<Reserva> {
+  const { data } = await axiosInstance.patch<Reserva>(`/reservas/${reservaId}/aceptar`);
+  return data;
+}
+
+export async function completeReserva(reservaId: number): Promise<Reserva> {
+  const { data } = await axiosInstance.patch<Reserva>(`/reservas/${reservaId}/completar`);
+  return data;
+}
+
+export async function getClienteReservas(clienteId: number): Promise<Reserva[]> {
+  const { data } = await axiosInstance.get<Reserva[]>(`/clientes/${clienteId}/reservas`);
+  return data;
+}
+
+export async function getProveedorReservas(proveedorId: number): Promise<Reserva[]> {
+  const { data } = await axiosInstance.get<Reserva[]>(`/proveedores/${proveedorId}/reservas`);
+  return data;
+}
+
+export async function getAllReservas(): Promise<Reserva[]> {
+  const { data } = await axiosInstance.get<Reserva[]>('/reservas');
+  return data;
+}

--- a/src/services/servicios.ts
+++ b/src/services/servicios.ts
@@ -22,7 +22,7 @@ export interface SearchParams {
 }
 
 export interface HorarioReq {
-  dia: string;
+  diaSemana: string;
   horaInicio: string;
   horaFin: string;
 }

--- a/src/services/servicios.ts
+++ b/src/services/servicios.ts
@@ -28,15 +28,23 @@ export interface HorarioReq {
 }
 
 export async function searchServicios(p: SearchParams): Promise<Servicio[]> {
-  const { data } = await axiosInstance.get<Servicio[]>('/servicios', { params: p });
+  const { data } = await axiosInstance.get<Servicio[]>('/api/servicios', {
+    params: p,
+  });
   return data;
 }
 
-export async function updateServicio(id: number, body: Partial<CreateServicioReq>): Promise<Servicio> {
-  const { data } = await axiosInstance.put<Servicio>(`/servicios/${id}`, body);
+export async function updateServicio(
+  id: number,
+  body: Partial<CreateServicioReq>,
+): Promise<Servicio> {
+  const { data } = await axiosInstance.put<Servicio>(`/api/servicios/${id}`, body);
   return data;
 }
 
-export async function setHorarios(servicioId: number, horarios: HorarioReq[]): Promise<void> {
-  await axiosInstance.post(`/servicios/${servicioId}/horarios`, horarios);
+export async function setHorarios(
+  servicioId: number,
+  horarios: HorarioReq[],
+): Promise<void> {
+  await axiosInstance.post(`/api/servicios/${servicioId}/horarios`, horarios);
 }

--- a/src/services/servicios.ts
+++ b/src/services/servicios.ts
@@ -1,0 +1,42 @@
+import { axiosInstance } from './axiosInstance';
+import type { CreateServicioReq } from './proveedores';
+
+export interface Servicio {
+  id: number;
+  nombre: string;
+  descripcion: string;
+  precio: number;
+  categoria: string;
+  proveedorId: number;
+}
+
+export interface SearchParams {
+  categoria?: string;
+  direccion?: string;
+  precioMin?: number;
+  precioMax?: number;
+  calificacionMin?: number;
+  page?: number;
+  size?: number;
+  proveedorId?: number;
+}
+
+export interface HorarioReq {
+  dia: string;
+  horaInicio: string;
+  horaFin: string;
+}
+
+export async function searchServicios(p: SearchParams): Promise<Servicio[]> {
+  const { data } = await axiosInstance.get<Servicio[]>('/servicios', { params: p });
+  return data;
+}
+
+export async function updateServicio(id: number, body: Partial<CreateServicioReq>): Promise<Servicio> {
+  const { data } = await axiosInstance.put<Servicio>(`/servicios/${id}`, body);
+  return data;
+}
+
+export async function setHorarios(servicioId: number, horarios: HorarioReq[]): Promise<void> {
+  await axiosInstance.post(`/servicios/${servicioId}/horarios`, horarios);
+}

--- a/src/utils/authHelpers.ts
+++ b/src/utils/authHelpers.ts
@@ -8,7 +8,7 @@ export function getAuthToken(): string | null {
   }
 }
 
-export function saveAuth(data: { userId: number; token: string; role: string }) {
+export function saveAuth(data: { id: number; token: string; role: string }) {
   localStorage.setItem('auth', JSON.stringify(data));
 }
 

--- a/src/utils/authHelpers.ts
+++ b/src/utils/authHelpers.ts
@@ -8,7 +8,7 @@ export function getAuthToken(): string | null {
   }
 }
 
-export function saveAuth(data: { id: number; token: string; role: string }) {
+export function saveAuth(data: { userId: number; token: string; role: string }) {
   localStorage.setItem('auth', JSON.stringify(data));
 }
 

--- a/src/utils/authHelpers.ts
+++ b/src/utils/authHelpers.ts
@@ -1,0 +1,17 @@
+export function getAuthToken(): string | null {
+  const raw = localStorage.getItem('auth');
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw).token as string;
+  } catch {
+    return null;
+  }
+}
+
+export function saveAuth(data: { userId: number; token: string; role: string }) {
+  localStorage.setItem('auth', JSON.stringify(data));
+}
+
+export function clearAuth() {
+  localStorage.removeItem('auth');
+}


### PR DESCRIPTION
## Summary
- implement `useStorageState` hook
- add axios instance with auth interceptor
- create auth helpers and context
- add protected routes and router config
- create service API modules
- build simple pages and reusable components
- wire up interceptors in `main.tsx`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685c285cff3c8330bf9ac234c6d1ad62